### PR TITLE
Close button should not be blocked when timeout is set

### DIFF
--- a/js/noty/packaged/jquery.noty.packaged.js
+++ b/js/noty/packaged/jquery.noty.packaged.js
@@ -169,9 +169,9 @@
 
             // If noty is have a timeout option
             if(self.options.timeout)
-                self.$bar.delay(self.options.timeout).promise().done(function() {
+                setTimeout(function() {
                     self.close();
-                });
+                }, self.options.timeout);
 
             return this;
 


### PR DESCRIPTION
Currently when timeout is set on an alert, it won't disappear when you click the close button, because of jquery's delay method delaying queued animations. Change this to use setTimeout.
